### PR TITLE
管理者ダッシュボード機能の実装（統計表示）

### DIFF
--- a/reserve-app/src/__tests__/e2e/admin-dashboard.spec.ts
+++ b/reserve-app/src/__tests__/e2e/admin-dashboard.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Feature: 管理者ダッシュボード（統計表示）
+ * Issue: #15
+ *
+ * ユーザーストーリー:
+ * As a store admin
+ * I want to view key metrics on a dashboard
+ * So that I can understand business performance
+ */
+
+test.describe('管理者ダッシュボード', () => {
+  test.beforeEach(async ({ page }) => {
+    // TODO: 管理者ログイン処理を実装後に追加
+    // 現在はログイン不要でダッシュボードに直接アクセス
+    await page.goto('/admin/dashboard');
+  });
+
+  /**
+   * Scenario: 統計データを表示
+   *   Given 管理者がログインしている
+   *   When ダッシュボードにアクセスする
+   *   Then 本日の予約件数が表示される
+   *   And 今月の予約件数が表示される
+   *   And 売上統計が表示される
+   */
+  test('統計データを表示する', async ({ page }) => {
+    // Then: 本日の予約件数が表示される
+    await expect(page.getByText('本日の予約')).toBeVisible();
+    const todayReservationsCard = page.locator('div', { has: page.getByText('本日の予約') }).first();
+    await expect(todayReservationsCard).toContainText(/\d+件/);
+
+    // And: 今月の予約件数が表示される
+    await expect(page.getByText('今月の予約')).toBeVisible();
+    const monthlyReservationsCard = page.locator('div', { has: page.getByText('今月の予約') }).first();
+    await expect(monthlyReservationsCard).toContainText(/\d+件/);
+
+    // And: 売上統計が表示される
+    await expect(page.getByText('今月の売上')).toBeVisible();
+    const revenueCard = page.locator('div', { has: page.getByText('今月の売上') }).first();
+    await expect(revenueCard).toContainText(/¥[\d,]+/);
+  });
+
+  /**
+   * Scenario: 本日の予約一覧を表示
+   *   Given 管理者がダッシュボードにアクセスしている
+   *   When ページが読み込まれる
+   *   Then 本日の予約一覧が表示される
+   *   And 各予約に時間、顧客名、メニュー、スタッフ、ステータスが表示される
+   */
+  test('本日の予約一覧を表示する', async ({ page }) => {
+    // Then: 本日の予約一覧が表示される
+    const reservationsSection = page.locator('h2', { hasText: '本日の予約' }).locator('..');
+    await expect(reservationsSection).toBeVisible();
+
+    // And: 予約の件数が表示される（最低1件）
+    const reservationItems = page.locator('[data-testid="reservation-item"]');
+    const count = await reservationItems.count();
+    expect(count).toBeGreaterThan(0);
+
+    // And: 各予約に必要な情報が表示される
+    if (count > 0) {
+      const firstReservation = reservationItems.first();
+      // 時間が表示される（HH:MM形式）
+      await expect(firstReservation).toContainText(/\d{1,2}:\d{2}/);
+      // ステータスバッジが表示される
+      await expect(firstReservation.locator('span[class*="rounded-full"]')).toBeVisible();
+    }
+  });
+
+  /**
+   * Scenario: 週間予約状況グラフを表示
+   *   Given 管理者がダッシュボードにアクセスしている
+   *   When ページが読み込まれる
+   *   Then 週間予約状況のグラフが表示される
+   *   And 月曜から日曜までの7日分が表示される
+   */
+  test('週間予約状況グラフを表示する', async ({ page }) => {
+    // Then: 週間予約状況のグラフが表示される
+    await expect(page.getByText('週間予約状況')).toBeVisible();
+
+    // And: 月曜から日曜までの7日分が表示される
+    const weekDays = ['月', '火', '水', '木', '金', '土', '日'];
+    for (const day of weekDays) {
+      await expect(page.getByText(day)).toBeVisible();
+    }
+  });
+
+  /**
+   * Scenario: リアルタイム更新
+   *   Given 管理者がダッシュボードにアクセスしている
+   *   When 新しい予約が追加される
+   *   Then ダッシュボードの統計が自動的に更新される
+   */
+  test.skip('リアルタイム更新（将来実装）', async ({ page }) => {
+    // このテストは将来のリアルタイム機能実装時に有効化
+  });
+
+  /**
+   * Scenario: スタッフ出勤状況を表示
+   *   Given 管理者がダッシュボードにアクセスしている
+   *   When ページが読み込まれる
+   *   Then スタッフ出勤状況が表示される
+   */
+  test('スタッフ出勤状況を表示する', async ({ page }) => {
+    // Then: スタッフ出勤状況が表示される
+    await expect(page.getByText('スタッフ出勤状況')).toBeVisible();
+
+    // And: スタッフ情報が表示される
+    const staffSection = page.locator('h3', { hasText: 'スタッフ出勤状況' }).locator('..');
+    await expect(staffSection).toBeVisible();
+  });
+
+  /**
+   * Scenario: クイックアクションボタン
+   *   Given 管理者がダッシュボードにアクセスしている
+   *   When クイックアクションを確認する
+   *   Then 新規予約追加ボタンが表示される
+   *   And 顧客追加ボタンが表示される
+   */
+  test('クイックアクションボタンを表示する', async ({ page }) => {
+    // Then: 新規予約追加ボタンが表示される
+    await expect(page.getByRole('button', { name: /新規予約を追加/ })).toBeVisible();
+
+    // And: 顧客追加ボタンが表示される
+    await expect(page.getByRole('button', { name: /顧客を追加/ })).toBeVisible();
+  });
+
+  /**
+   * Scenario: レスポンシブデザイン
+   *   Given 管理者がスマートフォンでアクセスしている
+   *   When ダッシュボードを表示する
+   *   Then モバイル用のレイアウトが適用される
+   */
+  test('モバイル表示に対応する', async ({ page }) => {
+    // モバイルビューポートに変更
+    await page.setViewportSize({ width: 375, height: 667 });
+
+    // ページを再読み込み
+    await page.reload();
+
+    // 統計カードが表示される
+    await expect(page.getByText('本日の予約')).toBeVisible();
+    await expect(page.getByText('今月の予約')).toBeVisible();
+  });
+});

--- a/reserve-app/src/app/api/admin/stats/route.ts
+++ b/reserve-app/src/app/api/admin/stats/route.ts
@@ -1,0 +1,210 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+/**
+ * GET /api/admin/stats
+ * 管理者ダッシュボード用の統計データを取得
+ *
+ * レスポンス:
+ * {
+ *   todayReservations: number,    // 本日の予約件数
+ *   monthlyReservations: number,  // 今月の予約件数
+ *   monthlyRevenue: number,       // 今月の売上
+ *   repeatRate: number,           // リピート率（%）
+ *   todayReservationsList: [...], // 本日の予約一覧
+ *   weeklyStats: [...]            // 週間予約件数（月〜日）
+ * }
+ */
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const tenantId = searchParams.get('tenantId') || process.env.NEXT_PUBLIC_TENANT_ID || 'demo-restaurant';
+
+    // 現在の日時情報
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const todayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+    // 本日の予約件数
+    const todayReservations = await prisma.restaurantReservation.count({
+      where: {
+        tenantId,
+        reservedDate: {
+          gte: todayStart,
+          lt: todayEnd,
+        },
+        status: { not: 'CANCELLED' },
+      },
+    });
+
+    // 今月の予約件数
+    const monthlyReservations = await prisma.restaurantReservation.count({
+      where: {
+        tenantId,
+        reservedDate: {
+          gte: monthStart,
+          lte: monthEnd,
+        },
+        status: { not: 'CANCELLED' },
+      },
+    });
+
+    // 本日の予約一覧（詳細情報付き）
+    const todayReservationsList = await prisma.restaurantReservation.findMany({
+      where: {
+        tenantId,
+        reservedDate: {
+          gte: todayStart,
+          lt: todayEnd,
+        },
+      },
+      include: {
+        user: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+        menu: {
+          select: {
+            name: true,
+            price: true,
+            duration: true,
+          },
+        },
+        staff: {
+          select: {
+            name: true,
+          },
+        },
+      },
+      orderBy: {
+        reservedDate: 'asc',
+      },
+    });
+
+    // 今月の売上計算
+    const monthlyReservationsWithPrice = await prisma.restaurantReservation.findMany({
+      where: {
+        tenantId,
+        reservedDate: {
+          gte: monthStart,
+          lte: monthEnd,
+        },
+        status: 'COMPLETED',
+      },
+      include: {
+        menu: {
+          select: {
+            price: true,
+          },
+        },
+      },
+    });
+
+    const monthlyRevenue = monthlyReservationsWithPrice.reduce(
+      (sum, reservation) => sum + (reservation.menu?.price || 0),
+      0
+    );
+
+    // リピート率計算（今月予約した顧客のうち、過去にも予約している人の割合）
+    const uniqueCustomersThisMonth = await prisma.restaurantReservation.findMany({
+      where: {
+        tenantId,
+        reservedDate: {
+          gte: monthStart,
+          lte: monthEnd,
+        },
+      },
+      select: {
+        userId: true,
+      },
+      distinct: ['userId'],
+    });
+
+    let repeatCustomers = 0;
+    for (const { userId } of uniqueCustomersThisMonth) {
+      const pastReservations = await prisma.restaurantReservation.count({
+        where: {
+          tenantId,
+          userId,
+          reservedDate: {
+            lt: monthStart,
+          },
+        },
+      });
+      if (pastReservations > 0) {
+        repeatCustomers++;
+      }
+    }
+
+    const repeatRate = uniqueCustomersThisMonth.length > 0
+      ? Math.round((repeatCustomers / uniqueCustomersThisMonth.length) * 100)
+      : 0;
+
+    // 週間統計（過去7日間の予約件数）
+    const weeklyStats = [];
+    for (let i = 6; i >= 0; i--) {
+      const dayStart = new Date(now);
+      dayStart.setDate(dayStart.getDate() - i);
+      dayStart.setHours(0, 0, 0, 0);
+
+      const dayEnd = new Date(dayStart);
+      dayEnd.setHours(23, 59, 59, 999);
+
+      const count = await prisma.restaurantReservation.count({
+        where: {
+          tenantId,
+          reservedDate: {
+            gte: dayStart,
+            lte: dayEnd,
+          },
+          status: { not: 'CANCELLED' },
+        },
+      });
+
+      weeklyStats.push({
+        date: dayStart.toISOString().split('T')[0],
+        day: ['日', '月', '火', '水', '木', '金', '土'][dayStart.getDay()],
+        count,
+      });
+    }
+
+    // レスポンス整形
+    const formattedReservations = todayReservationsList.map((reservation) => ({
+      id: reservation.id,
+      time: reservation.reservedTime, // "14:00" format
+      customer: reservation.user?.name || '名前未設定',
+      email: reservation.user?.email || '',
+      menu: reservation.menu?.name || 'メニュー未設定',
+      staff: reservation.staff?.name || 'スタッフ未設定',
+      status: reservation.status,
+      price: reservation.menu?.price || 0,
+      duration: reservation.menu?.duration || 0,
+    }));
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        todayReservations,
+        monthlyReservations,
+        monthlyRevenue,
+        repeatRate,
+        todayReservationsList: formattedReservations,
+        weeklyStats,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching admin stats:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to fetch admin statistics',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## 概要
Issue #15: 管理者ダッシュボード（統計表示）機能を実装しました。

## 実装内容

### 📊 統計データAPI（`/api/admin/stats`）
- 本日の予約件数取得
- 今月の予約件数取得
- 今月の売上集計
- 顧客リピート率計算
- 週間予約統計（過去7日間）
- 本日の予約一覧（詳細情報付き）

### 🎨 ダッシュボードUI
- モックデータから実際のAPI連携に変更
- ローディング・エラー状態の実装
- 空状態（予約なし）の表示対応
- 週間グラフの動的データ表示
- レスポンシブデザイン対応（モバイル表示）

### 🧪 テスト
- E2Eテストシナリオ作成（Playwright）
  - 統計データ表示のテスト
  - 予約一覧表示のテスト
  - 週間グラフ表示のテスト
  - モバイル表示のテスト

## 変更ファイル
- 新規作成: `src/app/api/admin/stats/route.ts`
- 新規作成: `src/__tests__/e2e/admin-dashboard.spec.ts`
- 変更: `src/app/admin/dashboard/page.tsx`

## スクリーンショット
（実際のデータベース接続後にスクリーンショットを追加予定）

## テスト方法
1. 開発サーバー起動: `npm run dev`
2. ダッシュボードにアクセス: http://localhost:3000/admin/dashboard
3. E2Eテスト実行: `npm run test:e2e`

## 関連Issue
Closes #15

## チェックリスト
- [x] APIエンドポイント実装
- [x] UIコンポーネント実装
- [x] E2Eテスト作成
- [x] TypeScript型定義
- [x] エラーハンドリング
- [ ] ビルド確認（Next.js 16のReact 19互換性問題あり）

🤖 Generated with [Claude Code](https://claude.com/claude-code)