### PR TITLE
[FIX] validationsテストの日付を2026年に更新

### DIFF
--- a/reserve-app/src/__tests__/unit/lib/validations.test.ts
+++ b/reserve-app/src/__tests__/unit/lib/validations.test.ts
@@ -8,7 +8,7 @@ describe('validations', () => {
   describe('availableSlotsQuerySchema', () => {
     it('should validate correct query parameters', () => {
       const validData = {
-        date: '2025-01-20',
+        date: '2026-01-20',
         menuId: '123e4567-e89b-12d3-a456-426614174000',
       };
 
@@ -18,7 +18,7 @@ describe('validations', () => {
 
     it('should validate with optional staffId', () => {
       const validData = {
-        date: '2025-01-20',
+        date: '2026-01-20',
         menuId: '123e4567-e89b-12d3-a456-426614174000',
         staffId: '123e4567-e89b-12d3-a456-426614174001',
       };
@@ -29,7 +29,7 @@ describe('validations', () => {
 
     it('should reject invalid date format', () => {
       const invalidData = {
-        date: '2025/01/20',
+        date: '2026/01/20',
         menuId: '123e4567-e89b-12d3-a456-426614174000',
       };
 
@@ -39,7 +39,7 @@ describe('validations', () => {
 
     it('should reject invalid menuId UUID', () => {
       const invalidData = {
-        date: '2025-01-20',
+        date: '2026-01-20',
         menuId: 'not-a-uuid',
       };
 
@@ -53,7 +53,7 @@ describe('validations', () => {
       const validData = {
         menuId: '123e4567-e89b-12d3-a456-426614174000',
         staffId: '123e4567-e89b-12d3-a456-426614174001',
-        reservedDate: '2025-12-31',
+        reservedDate: '2026-12-31',
         reservedTime: '14:00',
         notes: 'Window seat preferred',
       };
@@ -66,7 +66,7 @@ describe('validations', () => {
       const validData = {
         menuId: '123e4567-e89b-12d3-a456-426614174000',
         staffId: '123e4567-e89b-12d3-a456-426614174001',
-        reservedDate: '2025-12-31',
+        reservedDate: '2026-12-31',
         reservedTime: '14:00',
       };
 
@@ -90,7 +90,7 @@ describe('validations', () => {
       const invalidData = {
         menuId: '123e4567-e89b-12d3-a456-426614174000',
         staffId: '123e4567-e89b-12d3-a456-426614174001',
-        reservedDate: '2025-12-31',
+        reservedDate: '2026-12-31',
         reservedTime: '2:00 PM',
       };
 
@@ -102,7 +102,7 @@ describe('validations', () => {
       const invalidData = {
         menuId: '123e4567-e89b-12d3-a456-426614174000',
         staffId: '123e4567-e89b-12d3-a456-426614174001',
-        reservedDate: '2025-12-31',
+        reservedDate: '2026-12-31',
         reservedTime: '14:00',
         notes: 'a'.repeat(501),
       };
@@ -115,7 +115,7 @@ describe('validations', () => {
       const invalidData = {
         menuId: '123e4567-e89b-12d3-a456-426614174000',
         staffId: '123e4567-e89b-12d3-a456-426614174001',
-        reservedDate: '2025-12-31',
+        reservedDate: '2026-12-31',
         reservedTime: '24:00',
       };
 
@@ -136,7 +136,7 @@ describe('validations', () => {
 
     it('should validate multiple fields update', () => {
       const validData = {
-        reservedDate: '2025-12-31',
+        reservedDate: '2026-12-31',
         reservedTime: '15:00',
         notes: 'Updated notes',
       };


### PR DESCRIPTION
## 📝 概要
validationsテストで使用している日付が2025年だったため、バリデーションが過去日として拒否し、テストが失敗していました。テストデータを2026年に更新して修正しました。

## 🎯 関連Issue
なし（テスト失敗の修正）

## ✅ 実装内容
- [x] createReservationSchemaのテストケースの日付を2026年に更新
- [x] updateReservationSchemaのテストケースの日付を2026年に更新
- [x] availableSlotsQuerySchemaのテストケースの日付を2026年に更新

## 🐛 問題の詳細
- 今日の日付: 2026-01-01
- テストで使用していた日付: 2025-12-31
- バリデーションロジックが過去日を拒否するため、テストが失敗

## 🧪 テスト方法
```bash
npm test -- validations.test.ts
```

## 📊 品質チェック
- [x] ESLintエラー0件（警告6件のみ）
- [x] TypeScriptエラー0件
- [x] テスト通過（154 passed）
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)