### PR TITLE
feat: SKIP_AUTH_IN_TESTの本番環境での誤使用を防止

### DIFF
--- a/reserve-app/next.config.ts
+++ b/reserve-app/next.config.ts
@@ -1,5 +1,27 @@
 import type { NextConfig } from "next";
 
+// ビルド時の環境変数チェック
+// SKIP_AUTH_IN_TESTがproduction環境で有効になっていないか警告
+const checkProductionSecurity = () => {
+  const nodeEnv = process.env.NODE_ENV;
+  const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST;
+
+  // production環境でSKIP_AUTH_IN_TEST=trueが設定されている場合は警告
+  if (nodeEnv === 'production' && skipAuthInTest === 'true') {
+    console.warn('\n');
+    console.warn('⚠️  WARNING: SKIP_AUTH_IN_TEST is enabled in production!');
+    console.warn('⚠️  This is a security risk and should NEVER be used in production.');
+    console.warn('⚠️  Authentication bypass is only for E2E testing.');
+    console.warn('\n');
+
+    // 本番環境での事故を防ぐため、ビルドを失敗させることも検討できます
+    // throw new Error('SKIP_AUTH_IN_TEST must not be enabled in production');
+  }
+};
+
+// ビルド開始時にチェックを実行
+checkProductionSecurity();
+
 const nextConfig: NextConfig = {
   /**
    * セキュリティヘッダー設定

--- a/reserve-app/src/lib/auth.ts
+++ b/reserve-app/src/lib/auth.ts
@@ -146,8 +146,8 @@ export async function getAuthenticatedBookingUser(): Promise<{
  * @returns PrismaのBookingUser
  */
 export async function requireAuthAndGetBookingUser() {
-  // E2Eテスト環境では認証をスキップしてテスト用ユーザーを返す
-  const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST === 'true';
+  // E2Eテスト環境では認証をスキップしてテスト用ユーザーを返す（本番環境では無効）
+  const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
   if (skipAuthInTest) {
     // テスト用の既存ユーザー（シードデータの山田 太郎）を返す
     const testUser = await prisma.bookingUser.findFirst({
@@ -219,8 +219,8 @@ export function checkAuthHeader(
 export function checkAdminAuthHeader(
   request: NextRequest
 ): string | ReturnType<typeof errorResponse> {
-  // E2Eテスト環境では認証をスキップ
-  const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST === 'true';
+  // E2Eテスト環境では認証をスキップ（本番環境では無効）
+  const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
   if (skipAuthInTest) {
     return 'test-admin-user'; // テスト用のダミーユーザーIDを返す
   }

--- a/reserve-app/src/middleware.ts
+++ b/reserve-app/src/middleware.ts
@@ -143,8 +143,8 @@ export async function middleware(request: NextRequest) {
   if (pathname.startsWith('/super-admin/')) {
     // ログインページは除外
     if (!pathname.startsWith('/super-admin/login')) {
-      // E2Eテスト環境では認証をスキップ
-      const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST === 'true';
+      // E2Eテスト環境では認証をスキップ（本番環境では無効）
+      const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
       if (!skipAuthInTest) {
         const isAuthenticated = checkAuthentication(request);
         if (!isAuthenticated) {
@@ -165,8 +165,8 @@ export async function middleware(request: NextRequest) {
   if (pathname.startsWith('/admin/')) {
     // ログインページは除外
     if (!pathname.startsWith('/admin/login')) {
-      // E2Eテスト環境では認証をスキップ
-      const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST === 'true';
+      // E2Eテスト環境では認証をスキップ（本番環境では無効）
+      const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
       if (!skipAuthInTest) {
         const isAuthenticated = checkAuthentication(request);
         if (!isAuthenticated) {
@@ -186,8 +186,8 @@ export async function middleware(request: NextRequest) {
   const isProtectedPath = protectedPaths.some((path) => pathname.startsWith(path));
 
   if (isProtectedPath) {
-    // E2Eテスト環境では認証をスキップ
-    const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST === 'true';
+    // E2Eテスト環境では認証をスキップ（本番環境では無効）
+    const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
     if (!skipAuthInTest) {
       const isAuthenticated = checkAuthentication(request);
       if (!isAuthenticated) {


### PR DESCRIPTION
## 📝 概要

Issue #119の対応として、E2Eテスト用の認証バイパス機能（SKIP_AUTH_IN_TEST）が本番環境で誤って有効化されることを防ぐ多層防御を実装しました。

## 🎯 関連Issue

Closes #119

## 🔐 セキュリティリスク

**修正前の問題:**
- `SKIP_AUTH_IN_TEST=true`を設定すると、環境を問わず認証をバイパス可能
- 本番環境で誤って有効化すると、全ユーザーが認証なしでアクセス可能に
- 重大なセキュリティインシデントのリスク

## ✅ 実装内容

### 1. ランタイムガード - middleware.ts（3箇所）

```typescript
// 修正前
const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST === 'true';

// 修正後
const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
```

**対象箇所:**
- L147: スーパー管理者画面への認証チェック
- L169: 管理者画面への認証チェック
- L190: 保護ページへの認証チェック

### 2. APIルートガード - lib/auth.ts（2箇所）

```typescript
// requireAuthAndGetBookingUser() - L150
const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';

// checkAdminAuthHeader() - L223
const skipAuthInTest = process.env.NODE_ENV !== 'production' && process.env.SKIP_AUTH_IN_TEST === 'true';
```

### 3. ビルド時警告 - next.config.ts

```typescript
const checkProductionSecurity = () => {
  const nodeEnv = process.env.NODE_ENV;
  const skipAuthInTest = process.env.SKIP_AUTH_IN_TEST;

  if (nodeEnv === 'production' && skipAuthInTest === 'true') {
    console.warn('\n');
    console.warn('⚠️  WARNING: SKIP_AUTH_IN_TEST is enabled in production!');
    console.warn('⚠️  This is a security risk and should NEVER be used in production.');
    console.warn('⚠️  Authentication bypass is only for E2E testing.');
    console.warn('\n');
  }
};

checkProductionSecurity();
```

## 🛡️ 多層防御アプローチ

この実装により、以下の3層防御を実現：

| レイヤー | 実装箇所 | 効果 |
|---------|---------|------|
| **Layer 1** | middleware.ts | リクエスト単位で本番環境での認証バイパスをブロック |
| **Layer 2** | lib/auth.ts | API関数レベルで本番環境での認証バイパスをブロック |
| **Layer 3** | next.config.ts | ビルド時に誤設定を検出・警告 |

## 🧪 テスト方法

### 開発環境（認証バイパスが動作）

```bash
# .env.localに設定
NODE_ENV=development
SKIP_AUTH_IN_TEST=true

npm run dev
# → 認証なしでアクセス可能（E2Eテスト用）
```

### 本番環境（認証バイパスが無効化）

```bash
# 本番環境で誤って設定した場合
NODE_ENV=production
SKIP_AUTH_IN_TEST=true

npm run build
# → ビルド時に警告が表示される

npm start
# → 認証バイパスは無効化され、通常の認証が必須
```

## 📊 品質チェック

- [x] **Lint**: エラー0件
- [x] **Build**: 成功（DATABASE_URL=dummyで実行）
- [x] **セキュリティ**: 本番環境で認証バイパスが無効化されることを確認
- [x] **後方互換性**: E2Eテストは引き続き動作（development/test環境）

## 🔍 動作確認

### 確認項目

1. **開発環境でのE2Eテスト**
   - SKIP_AUTH_IN_TEST=true で認証バイパスが動作
   - テストが正常に実行される

2. **本番環境での保護**
   - SKIP_AUTH_IN_TEST=true でも認証バイパスが無効
   - 通常の認証フローが動作

3. **ビルド時警告**
   - NODE_ENV=production かつ SKIP_AUTH_IN_TEST=true で警告表示

## 📋 レビューポイント

- [ ] middleware.ts の3箇所すべてで NODE_ENV チェックが追加されているか
- [ ] lib/auth.ts の2箇所で NODE_ENV チェックが追加されているか
- [ ] next.config.ts のビルド時チェックが適切に動作するか
- [ ] コメントが日本語で適切に記述されているか

## 🚀 デプロイ後の確認事項

1. Vercel環境変数で `SKIP_AUTH_IN_TEST` が設定されていないことを確認
2. 本番環境で認証が正常に動作することを確認
3. E2E テスト環境（CI/CD）で認証バイパスが動作することを確認

## 📚 参考

- [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html)
- [Next.js Environment Variables](https://nextjs.org/docs/app/building-your-application/configuring/environment-variables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)