### PR TITLE
[TEST] カバレッジ0%ファイルのユニットテストを追加

### DIFF
--- a/reserve-app/src/__tests__/unit/components/admin/reservations/AddReservationModal.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/reservations/AddReservationModal.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * AddReservationModal.tsx のユニットテスト
+ *
+ * 予約追加モーダルコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import AddReservationModal from '@/components/admin/reservations/AddReservationModal';
+
+describe('AddReservationModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSubmit = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('モーダルが正しく表示される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('add-reservation-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-title')).toHaveTextContent('新規予約を追加');
+    });
+
+    it('全てのフォームフィールドが表示される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-customer-select')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-menu-select')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-staff-select')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-date-picker')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-time-select')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-notes')).toBeInTheDocument();
+    });
+
+    it('キャンセルと作成ボタンが表示される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-submit-button')).toBeInTheDocument();
+    });
+
+    it('prefilledDateとprefilledTimeが設定される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+          prefilledDate="2025-01-20"
+          prefilledTime="14:00"
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-date-picker')).toHaveValue('2025-01-20');
+      expect(screen.getByTestId('add-modal-time-select')).toHaveValue('14:00');
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('add-modal-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('フォームフィールドに入力できる', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-customer-select'), { target: { value: '山田太郎' } });
+      fireEvent.change(screen.getByTestId('add-modal-menu-select'), { target: { value: 'カット' } });
+      fireEvent.change(screen.getByTestId('add-modal-staff-select'), { target: { value: '田中' } });
+      fireEvent.change(screen.getByTestId('add-modal-date-picker'), { target: { value: '2025-01-20' } });
+      fireEvent.change(screen.getByTestId('add-modal-time-select'), { target: { value: '14:00' } });
+      fireEvent.change(screen.getByTestId('add-modal-notes'), { target: { value: 'テスト備考' } });
+
+      expect(screen.getByTestId('add-modal-customer-select')).toHaveValue('山田太郎');
+      expect(screen.getByTestId('add-modal-menu-select')).toHaveValue('カット');
+      expect(screen.getByTestId('add-modal-staff-select')).toHaveValue('田中');
+      expect(screen.getByTestId('add-modal-date-picker')).toHaveValue('2025-01-20');
+      expect(screen.getByTestId('add-modal-time-select')).toHaveValue('14:00');
+      expect(screen.getByTestId('add-modal-notes')).toHaveValue('テスト備考');
+    });
+  });
+
+  describe('バリデーション', () => {
+    it('必須項目が未入力の場合、バリデーションエラーが表示される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('add-modal-submit-button'));
+
+      expect(screen.getByTestId('add-modal-validation-error')).toHaveTextContent('必須項目を入力してください');
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+
+    it('顧客のみ入力した場合、バリデーションエラーが表示される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-customer-select'), { target: { value: '山田太郎' } });
+      fireEvent.click(screen.getByTestId('add-modal-submit-button'));
+
+      expect(screen.getByTestId('add-modal-validation-error')).toBeInTheDocument();
+      expect(mockOnSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('フォーム送信', () => {
+    it('全ての必須項目を入力すると、onSubmitが呼ばれる', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-customer-select'), { target: { value: '山田太郎' } });
+      fireEvent.change(screen.getByTestId('add-modal-menu-select'), { target: { value: 'カット' } });
+      fireEvent.change(screen.getByTestId('add-modal-staff-select'), { target: { value: '田中' } });
+      fireEvent.change(screen.getByTestId('add-modal-date-picker'), { target: { value: '2025-01-20' } });
+      fireEvent.change(screen.getByTestId('add-modal-time-select'), { target: { value: '14:00' } });
+
+      fireEvent.click(screen.getByTestId('add-modal-submit-button'));
+
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        customer: '山田太郎',
+        menu: 'カット',
+        staff: '田中',
+        date: '2025-01-20',
+        time: '14:00',
+        notes: '',
+      });
+    });
+
+    it('備考を含めたフォームデータが正しく送信される', () => {
+      render(
+        <AddReservationModal
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-customer-select'), { target: { value: '佐藤花子' } });
+      fireEvent.change(screen.getByTestId('add-modal-menu-select'), { target: { value: 'カラー' } });
+      fireEvent.change(screen.getByTestId('add-modal-staff-select'), { target: { value: '佐藤' } });
+      fireEvent.change(screen.getByTestId('add-modal-date-picker'), { target: { value: '2025-01-25' } });
+      fireEvent.change(screen.getByTestId('add-modal-time-select'), { target: { value: '10:00' } });
+      fireEvent.change(screen.getByTestId('add-modal-notes'), { target: { value: '初回のお客様' } });
+
+      fireEvent.click(screen.getByTestId('add-modal-submit-button'));
+
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        customer: '佐藤花子',
+        menu: 'カラー',
+        staff: '佐藤',
+        date: '2025-01-25',
+        time: '10:00',
+        notes: '初回のお客様',
+      });
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/reservations/DeleteReservationDialog.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/reservations/DeleteReservationDialog.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * DeleteReservationDialog.tsx のユニットテスト
+ *
+ * 予約削除確認ダイアログコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeleteReservationDialog from '@/components/admin/reservations/DeleteReservationDialog';
+import type { Reservation } from '@/components/admin/reservations/types';
+
+describe('DeleteReservationDialog', () => {
+  const mockOnClose = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  const mockReservation: Reservation = {
+    id: 'test-reservation-1',
+    reservedDate: '2025-01-20',
+    reservedTime: '14:00',
+    customerName: '山田太郎',
+    menuName: 'カット',
+    staffName: '田中',
+    status: 'CONFIRMED',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('ダイアログが正しく表示される', () => {
+      render(
+        <DeleteReservationDialog
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      expect(screen.getByTestId('delete-confirmation-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-dialog-title')).toHaveTextContent('予約を削除しますか？');
+    });
+
+    it('予約情報が表示される', () => {
+      render(
+        <DeleteReservationDialog
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-date')).toHaveTextContent('2025-01-20 14:00');
+      expect(screen.getByTestId('delete-dialog-customer')).toHaveTextContent('山田太郎');
+      expect(screen.getByTestId('delete-dialog-menu')).toHaveTextContent('カット');
+    });
+
+    it('警告メッセージが表示される', () => {
+      render(
+        <DeleteReservationDialog
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-warning')).toHaveTextContent('この操作は取り消せません');
+    });
+
+    it('キャンセルと削除ボタンが表示される', () => {
+      render(
+        <DeleteReservationDialog
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-dialog-confirm-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('戻るボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <DeleteReservationDialog
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('delete-dialog-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+
+    it('削除するボタンをクリックするとonConfirmが呼ばれる', () => {
+      render(
+        <DeleteReservationDialog
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('delete-dialog-confirm-button'));
+      expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異なる予約データの表示', () => {
+    it('別の予約データが正しく表示される', () => {
+      const anotherReservation: Reservation = {
+        id: 'test-reservation-2',
+        reservedDate: '2025-02-15',
+        reservedTime: '10:00',
+        customerName: '佐藤花子',
+        menuName: 'カラー',
+        staffName: '佐藤',
+        status: 'PENDING',
+      };
+
+      render(
+        <DeleteReservationDialog
+          reservation={anotherReservation}
+          onClose={mockOnClose}
+          onConfirm={mockOnConfirm}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-date')).toHaveTextContent('2025-02-15 10:00');
+      expect(screen.getByTestId('delete-dialog-customer')).toHaveTextContent('佐藤花子');
+      expect(screen.getByTestId('delete-dialog-menu')).toHaveTextContent('カラー');
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/reservations/EditReservationModal.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/reservations/EditReservationModal.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * EditReservationModal.tsx のユニットテスト
+ *
+ * 予約編集モーダルコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditReservationModal from '@/components/admin/reservations/EditReservationModal';
+import type { Reservation } from '@/components/admin/reservations/types';
+
+describe('EditReservationModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSubmit = jest.fn();
+
+  const mockReservation: Reservation = {
+    id: 'test-reservation-1',
+    reservedDate: '2025-01-20',
+    reservedTime: '14:00',
+    customerName: '山田太郎',
+    menuName: 'カット',
+    staffName: '田中',
+    status: 'CONFIRMED',
+    notes: 'テスト備考',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('モーダルが正しく表示される', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('edit-reservation-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-title')).toHaveTextContent('予約を編集');
+    });
+
+    it('全てのフォームフィールドが表示される', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-menu-select')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-staff-select')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-date-picker')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-time-select')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-status-select')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-notes')).toBeInTheDocument();
+    });
+
+    it('予約データが初期値として設定される', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-menu-select')).toHaveValue('カット');
+      expect(screen.getByTestId('edit-modal-staff-select')).toHaveValue('田中');
+      expect(screen.getByTestId('edit-modal-date-picker')).toHaveValue('2025-01-20');
+      expect(screen.getByTestId('edit-modal-time-select')).toHaveValue('14:00');
+      expect(screen.getByTestId('edit-modal-status-select')).toHaveValue('CONFIRMED');
+      expect(screen.getByTestId('edit-modal-notes')).toHaveValue('テスト備考');
+    });
+
+    it('キャンセルと更新ボタンが表示される', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-submit-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('edit-modal-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('フォームフィールドを変更できる', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('edit-modal-menu-select'), { target: { value: 'カラー' } });
+      fireEvent.change(screen.getByTestId('edit-modal-staff-select'), { target: { value: '佐藤' } });
+      fireEvent.change(screen.getByTestId('edit-modal-date-picker'), { target: { value: '2025-01-25' } });
+      fireEvent.change(screen.getByTestId('edit-modal-time-select'), { target: { value: '10:00' } });
+      fireEvent.change(screen.getByTestId('edit-modal-status-select'), { target: { value: 'PENDING' } });
+      fireEvent.change(screen.getByTestId('edit-modal-notes'), { target: { value: '変更した備考' } });
+
+      expect(screen.getByTestId('edit-modal-menu-select')).toHaveValue('カラー');
+      expect(screen.getByTestId('edit-modal-staff-select')).toHaveValue('佐藤');
+      expect(screen.getByTestId('edit-modal-date-picker')).toHaveValue('2025-01-25');
+      expect(screen.getByTestId('edit-modal-time-select')).toHaveValue('10:00');
+      expect(screen.getByTestId('edit-modal-status-select')).toHaveValue('PENDING');
+      expect(screen.getByTestId('edit-modal-notes')).toHaveValue('変更した備考');
+    });
+  });
+
+  describe('フォーム送信', () => {
+    it('更新ボタンをクリックするとonSubmitが呼ばれる', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('edit-modal-submit-button'));
+
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        menu: 'カット',
+        staff: '田中',
+        date: '2025-01-20',
+        time: '14:00',
+        status: 'CONFIRMED',
+        notes: 'テスト備考',
+      });
+    });
+
+    it('変更したデータが正しく送信される', () => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('edit-modal-menu-select'), { target: { value: 'カラー' } });
+      fireEvent.change(screen.getByTestId('edit-modal-status-select'), { target: { value: 'CANCELLED' } });
+      fireEvent.click(screen.getByTestId('edit-modal-submit-button'));
+
+      expect(mockOnSubmit).toHaveBeenCalledWith({
+        menu: 'カラー',
+        staff: '田中',
+        date: '2025-01-20',
+        time: '14:00',
+        status: 'CANCELLED',
+        notes: 'テスト備考',
+      });
+    });
+  });
+
+  describe('各ステータスの表示', () => {
+    it.each([
+      ['PENDING', '保留'],
+      ['CONFIRMED', '確定'],
+      ['CANCELLED', 'キャンセル'],
+    ])('ステータス %s が選択可能', (status) => {
+      render(
+        <EditReservationModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onSubmit={mockOnSubmit}
+        />
+      );
+
+      const statusSelect = screen.getByTestId('edit-modal-status-select');
+      fireEvent.change(statusSelect, { target: { value: status } });
+      expect(statusSelect).toHaveValue(status);
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/reservations/ReservationDetailModal.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/reservations/ReservationDetailModal.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * ReservationDetailModal.tsx のユニットテスト
+ *
+ * 予約詳細モーダルコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import ReservationDetailModal from '@/components/admin/reservations/ReservationDetailModal';
+import type { Reservation } from '@/components/admin/reservations/types';
+
+describe('ReservationDetailModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnEdit = jest.fn();
+  const mockOnCancel = jest.fn();
+
+  const mockReservation: Reservation = {
+    id: 'test-reservation-1',
+    reservedDate: '2025-01-20',
+    reservedTime: '14:00',
+    customerName: '山田太郎',
+    menuName: 'カット',
+    staffName: '田中',
+    status: 'CONFIRMED',
+    notes: 'テスト備考',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('モーダルが正しく表示される', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.getByTestId('reservation-detail-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('detail-modal-title')).toHaveTextContent('予約詳細');
+    });
+
+    it('予約情報が正しく表示される', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.getByTestId('detail-modal-customer')).toHaveTextContent('山田太郎');
+      expect(screen.getByTestId('detail-modal-menu')).toHaveTextContent('カット');
+      expect(screen.getByTestId('detail-modal-staff')).toHaveTextContent('田中');
+      expect(screen.getByTestId('detail-modal-date')).toHaveTextContent('2025-01-20');
+      expect(screen.getByTestId('detail-modal-time')).toHaveTextContent('14:00');
+    });
+
+    it('備考が表示される', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.getByTestId('detail-modal-notes')).toHaveTextContent('テスト備考');
+    });
+
+    it('備考がない場合は備考セクションが表示されない', () => {
+      const reservationWithoutNotes: Reservation = {
+        ...mockReservation,
+        notes: undefined,
+      };
+
+      render(
+        <ReservationDetailModal
+          reservation={reservationWithoutNotes}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.queryByTestId('detail-modal-notes')).not.toBeInTheDocument();
+    });
+
+    it('全てのアクションボタンが表示される', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.getByTestId('detail-modal-close-button')).toBeInTheDocument();
+      expect(screen.getByTestId('detail-modal-edit-button')).toBeInTheDocument();
+      expect(screen.getByTestId('detail-modal-cancel-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('ステータス表示', () => {
+    it.each([
+      ['CONFIRMED', '確定済み'],
+      ['PENDING', '保留中'],
+      ['CANCELLED', 'キャンセル済み'],
+      ['COMPLETED', '完了'],
+      ['NO_SHOW', '無断キャンセル'],
+    ] as const)('ステータス %s が %s と表示される', (status, expectedText) => {
+      const reservationWithStatus: Reservation = {
+        ...mockReservation,
+        status,
+      };
+
+      render(
+        <ReservationDetailModal
+          reservation={reservationWithStatus}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.getByTestId('detail-modal-status')).toHaveTextContent(expectedText);
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('閉じるボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('detail-modal-close-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('編集ボタンをクリックするとonEditが呼ばれる', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('detail-modal-edit-button'));
+      expect(mockOnEdit).toHaveBeenCalledTimes(1);
+    });
+
+    it('キャンセルボタンをクリックするとonCancelが呼ばれる', () => {
+      render(
+        <ReservationDetailModal
+          reservation={mockReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('detail-modal-cancel-button'));
+      expect(mockOnCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('異なる予約データの表示', () => {
+    it('別の予約データが正しく表示される', () => {
+      const anotherReservation: Reservation = {
+        id: 'test-reservation-2',
+        reservedDate: '2025-02-15',
+        reservedTime: '10:00',
+        customerName: '佐藤花子',
+        menuName: 'カラー',
+        staffName: '佐藤',
+        status: 'PENDING',
+        notes: '初回来店',
+      };
+
+      render(
+        <ReservationDetailModal
+          reservation={anotherReservation}
+          onClose={mockOnClose}
+          onEdit={mockOnEdit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      expect(screen.getByTestId('detail-modal-customer')).toHaveTextContent('佐藤花子');
+      expect(screen.getByTestId('detail-modal-menu')).toHaveTextContent('カラー');
+      expect(screen.getByTestId('detail-modal-staff')).toHaveTextContent('佐藤');
+      expect(screen.getByTestId('detail-modal-date')).toHaveTextContent('2025-02-15');
+      expect(screen.getByTestId('detail-modal-time')).toHaveTextContent('10:00');
+      expect(screen.getByTestId('detail-modal-status')).toHaveTextContent('保留中');
+      expect(screen.getByTestId('detail-modal-notes')).toHaveTextContent('初回来店');
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/staff/AddStaffModal.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/staff/AddStaffModal.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * AddStaffModal.tsx のユニットテスト
+ *
+ * スタッフ追加モーダルコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import AddStaffModal from '@/components/admin/staff/AddStaffModal';
+import type { StaffFormData } from '@/components/admin/staff/types';
+
+describe('AddStaffModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSubmit = jest.fn((e: React.FormEvent) => e.preventDefault());
+  const mockOnFormChange = jest.fn();
+
+  const defaultFormData: StaffFormData = {
+    name: '',
+    email: '',
+    phone: '',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('モーダルが正しく表示される', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('add-staff-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-title')).toHaveTextContent('スタッフを追加');
+    });
+
+    it('全てのフォームフィールドが表示される', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-name-input')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-email-input')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-phone-input')).toBeInTheDocument();
+    });
+
+    it('キャンセルと追加ボタンが表示される', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('add-modal-submit-button')).toBeInTheDocument();
+    });
+
+    it('フォームデータが初期値として設定される', () => {
+      const formDataWithValues: StaffFormData = {
+        name: '佐藤花子',
+        email: 'sato@example.com',
+        phone: '090-1234-5678',
+      };
+
+      render(
+        <AddStaffModal
+          formData={formDataWithValues}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-name-input')).toHaveValue('佐藤花子');
+      expect(screen.getByTestId('add-modal-email-input')).toHaveValue('sato@example.com');
+      expect(screen.getByTestId('add-modal-phone-input')).toHaveValue('090-1234-5678');
+    });
+  });
+
+  describe('エラー表示', () => {
+    it('エラーがない場合はエラーメッセージが表示されない', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.queryByTestId('add-modal-validation-error')).not.toBeInTheDocument();
+    });
+
+    it('エラーがある場合はエラーメッセージが表示される', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error="名前を入力してください"
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('add-modal-validation-error')).toHaveTextContent('名前を入力してください');
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('add-modal-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('名前を入力するとonFormChangeが呼ばれる', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-name-input'), { target: { value: '田中太郎' } });
+      expect(mockOnFormChange).toHaveBeenCalledWith({ ...defaultFormData, name: '田中太郎' });
+    });
+
+    it('メールアドレスを入力するとonFormChangeが呼ばれる', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-email-input'), { target: { value: 'tanaka@example.com' } });
+      expect(mockOnFormChange).toHaveBeenCalledWith({ ...defaultFormData, email: 'tanaka@example.com' });
+    });
+
+    it('電話番号を入力するとonFormChangeが呼ばれる', () => {
+      render(
+        <AddStaffModal
+          formData={defaultFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('add-modal-phone-input'), { target: { value: '090-9999-8888' } });
+      expect(mockOnFormChange).toHaveBeenCalledWith({ ...defaultFormData, phone: '090-9999-8888' });
+    });
+  });
+
+  describe('フォーム送信', () => {
+    it('必須項目を入力してフォームを送信するとonSubmitが呼ばれる', () => {
+      const filledFormData: StaffFormData = {
+        name: '田中太郎',
+        email: 'tanaka@example.com',
+        phone: '',
+      };
+
+      render(
+        <AddStaffModal
+          formData={filledFormData}
+          error={null}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('add-modal-submit-button'));
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/staff/DeleteStaffDialog.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/staff/DeleteStaffDialog.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * DeleteStaffDialog.tsx のユニットテスト
+ *
+ * スタッフ削除確認ダイアログコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import DeleteStaffDialog from '@/components/admin/staff/DeleteStaffDialog';
+import type { Staff } from '@/components/admin/staff/types';
+
+describe('DeleteStaffDialog', () => {
+  const mockOnClose = jest.fn();
+  const mockOnConfirm = jest.fn();
+
+  const mockStaff: Staff = {
+    id: 'staff-1',
+    name: '田中太郎',
+    email: 'tanaka@example.com',
+    phone: '090-1234-5678',
+    isActive: true,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('ダイアログが正しく表示される', () => {
+      render(
+        <DeleteStaffDialog
+          staff={mockStaff}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('delete-confirmation-dialog')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-dialog-title')).toHaveTextContent('スタッフを削除しますか？');
+    });
+
+    it('スタッフ名を含むメッセージが表示される', () => {
+      render(
+        <DeleteStaffDialog
+          staff={mockStaff}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-message')).toHaveTextContent('田中太郎を削除します');
+      expect(screen.getByTestId('delete-dialog-message')).toHaveTextContent('この操作は取り消せません');
+    });
+
+    it('キャンセルと削除ボタンが表示される', () => {
+      render(
+        <DeleteStaffDialog
+          staff={mockStaff}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('delete-dialog-confirm-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <DeleteStaffDialog
+          staff={mockStaff}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('delete-dialog-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+      expect(mockOnConfirm).not.toHaveBeenCalled();
+    });
+
+    it('削除ボタンをクリックするとonConfirmが呼ばれる', () => {
+      render(
+        <DeleteStaffDialog
+          staff={mockStaff}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('delete-dialog-confirm-button'));
+      expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+      expect(mockOnClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異なるスタッフデータの表示', () => {
+    it('別のスタッフ名が正しく表示される', () => {
+      const anotherStaff: Staff = {
+        id: 'staff-2',
+        name: '佐藤花子',
+        email: 'sato@example.com',
+        isActive: true,
+      };
+
+      render(
+        <DeleteStaffDialog
+          staff={anotherStaff}
+          onConfirm={mockOnConfirm}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('delete-dialog-message')).toHaveTextContent('佐藤花子を削除します');
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/staff/EditStaffModal.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/staff/EditStaffModal.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * EditStaffModal.tsx のユニットテスト
+ *
+ * スタッフ編集モーダルコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import EditStaffModal from '@/components/admin/staff/EditStaffModal';
+import type { StaffFormData } from '@/components/admin/staff/types';
+
+describe('EditStaffModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnSubmit = jest.fn((e: React.FormEvent) => e.preventDefault());
+  const mockOnFormChange = jest.fn();
+
+  const mockFormData: StaffFormData = {
+    name: '田中太郎',
+    email: 'tanaka@example.com',
+    phone: '090-1234-5678',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング', () => {
+    it('モーダルが正しく表示される', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('edit-staff-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-title')).toHaveTextContent('スタッフを編集');
+    });
+
+    it('全てのフォームフィールドが表示される', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-name-input')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-email-input')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-phone-input')).toBeInTheDocument();
+    });
+
+    it('フォームデータが初期値として設定される', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-name-input')).toHaveValue('田中太郎');
+      expect(screen.getByTestId('edit-modal-email-input')).toHaveValue('tanaka@example.com');
+      expect(screen.getByTestId('edit-modal-phone-input')).toHaveValue('090-1234-5678');
+    });
+
+    it('キャンセルと保存ボタンが表示される', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('edit-modal-submit-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('ユーザーインタラクション', () => {
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('edit-modal-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('名前を変更するとonFormChangeが呼ばれる', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('edit-modal-name-input'), { target: { value: '佐藤花子' } });
+      expect(mockOnFormChange).toHaveBeenCalledWith({ ...mockFormData, name: '佐藤花子' });
+    });
+
+    it('メールアドレスを変更するとonFormChangeが呼ばれる', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('edit-modal-email-input'), { target: { value: 'sato@example.com' } });
+      expect(mockOnFormChange).toHaveBeenCalledWith({ ...mockFormData, email: 'sato@example.com' });
+    });
+
+    it('電話番号を変更するとonFormChangeが呼ばれる', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('edit-modal-phone-input'), { target: { value: '090-9999-8888' } });
+      expect(mockOnFormChange).toHaveBeenCalledWith({ ...mockFormData, phone: '090-9999-8888' });
+    });
+  });
+
+  describe('フォーム送信', () => {
+    it('フォームを送信するとonSubmitが呼ばれる', () => {
+      render(
+        <EditStaffModal
+          formData={mockFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('edit-modal-submit-button'));
+      expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('異なるフォームデータの表示', () => {
+    it('別のフォームデータが正しく表示される', () => {
+      const anotherFormData: StaffFormData = {
+        name: '山田次郎',
+        email: 'yamada@example.com',
+        phone: '080-1111-2222',
+      };
+
+      render(
+        <EditStaffModal
+          formData={anotherFormData}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-name-input')).toHaveValue('山田次郎');
+      expect(screen.getByTestId('edit-modal-email-input')).toHaveValue('yamada@example.com');
+      expect(screen.getByTestId('edit-modal-phone-input')).toHaveValue('080-1111-2222');
+    });
+
+    it('電話番号がない場合も正しく表示される', () => {
+      const formDataWithoutPhone: StaffFormData = {
+        name: '鈴木一郎',
+        email: 'suzuki@example.com',
+        phone: '',
+      };
+
+      render(
+        <EditStaffModal
+          formData={formDataWithoutPhone}
+          onFormChange={mockOnFormChange}
+          onSubmit={mockOnSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('edit-modal-name-input')).toHaveValue('鈴木一郎');
+      expect(screen.getByTestId('edit-modal-email-input')).toHaveValue('suzuki@example.com');
+      expect(screen.getByTestId('edit-modal-phone-input')).toHaveValue('');
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/components/admin/staff/ShiftSettingModal.test.tsx
+++ b/reserve-app/src/__tests__/unit/components/admin/staff/ShiftSettingModal.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * ShiftSettingModal.tsx のユニットテスト
+ *
+ * シフト設定モーダルコンポーネントのテスト
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShiftSettingModal from '@/components/admin/staff/ShiftSettingModal';
+import type { Staff, ShiftFormData, VacationFormData } from '@/components/admin/staff/types';
+
+describe('ShiftSettingModal', () => {
+  const mockOnClose = jest.fn();
+  const mockOnTabChange = jest.fn();
+  const mockOnShiftFormChange = jest.fn();
+  const mockOnVacationFormChange = jest.fn();
+  const mockOnShiftSubmit = jest.fn((e: React.FormEvent) => e.preventDefault());
+  const mockOnVacationSubmit = jest.fn((e: React.FormEvent) => e.preventDefault());
+
+  const mockStaff: Staff = {
+    id: 'staff-1',
+    name: '田中太郎',
+    email: 'tanaka@example.com',
+    isActive: true,
+  };
+
+  const defaultShiftFormData: ShiftFormData = {
+    '月曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+    '火曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+    '水曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+    '木曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+    '金曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+    '土曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+    '日曜日': { enabled: false, startTime: '09:00', endTime: '18:00' },
+  };
+
+  const defaultVacationFormData: VacationFormData = {
+    startDate: '',
+    endDate: '',
+    reason: '',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('レンダリング - シフト設定タブ', () => {
+    it('モーダルが正しく表示される', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('shift-setting-modal')).toBeInTheDocument();
+      expect(screen.getByTestId('shift-modal-title')).toHaveTextContent('シフト設定 - 田中太郎');
+    });
+
+    it('全曜日のシフト設定フィールドが表示される', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      const checkboxes = screen.getAllByTestId('shift-day-checkbox');
+      expect(checkboxes).toHaveLength(7);
+
+      const startTimeInputs = screen.getAllByTestId('shift-start-time');
+      expect(startTimeInputs).toHaveLength(7);
+
+      const endTimeInputs = screen.getAllByTestId('shift-end-time');
+      expect(endTimeInputs).toHaveLength(7);
+    });
+
+    it('ボタンが表示される', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('shift-modal-cancel-button')).toBeInTheDocument();
+      expect(screen.getByTestId('shift-modal-submit-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('レンダリング - 休暇設定タブ', () => {
+    it('休暇設定フォームが表示される', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="vacation"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('vacation-start-date')).toBeInTheDocument();
+      expect(screen.getByTestId('vacation-end-date')).toBeInTheDocument();
+    });
+
+    it('休暇設定タブをクリックするとonTabChangeが呼ばれる', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('vacation-tab'));
+      expect(mockOnTabChange).toHaveBeenCalledWith('vacation');
+    });
+  });
+
+  describe('エラー表示', () => {
+    it('エラーがない場合はエラーメッセージが表示されない', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.queryByTestId('shift-modal-validation-error')).not.toBeInTheDocument();
+    });
+
+    it('エラーがある場合はエラーメッセージが表示される', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error="退勤時間は出勤時間より後である必要があります"
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('shift-modal-validation-error')).toHaveTextContent('退勤時間は出勤時間より後である必要があります');
+    });
+  });
+
+  describe('ユーザーインタラクション - シフト設定', () => {
+    it('キャンセルボタンをクリックするとonCloseが呼ばれる', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('shift-modal-cancel-button'));
+      expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('曜日のチェックボックスを変更するとonShiftFormChangeが呼ばれる', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      const checkboxes = screen.getAllByTestId('shift-day-checkbox');
+      fireEvent.click(checkboxes[0]); // 月曜日
+      expect(mockOnShiftFormChange).toHaveBeenCalled();
+    });
+
+    it('フォームを送信するとonShiftSubmitが呼ばれる', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('shift-modal-submit-button'));
+      expect(mockOnShiftSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ユーザーインタラクション - 休暇設定', () => {
+    it('休暇開始日を変更するとonVacationFormChangeが呼ばれる', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="vacation"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('vacation-start-date'), { target: { value: '2025-01-25' } });
+      expect(mockOnVacationFormChange).toHaveBeenCalledWith({
+        ...defaultVacationFormData,
+        startDate: '2025-01-25',
+      });
+    });
+
+    it('休暇終了日を変更するとonVacationFormChangeが呼ばれる', () => {
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="vacation"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.change(screen.getByTestId('vacation-end-date'), { target: { value: '2025-01-27' } });
+      expect(mockOnVacationFormChange).toHaveBeenCalledWith({
+        ...defaultVacationFormData,
+        endDate: '2025-01-27',
+      });
+    });
+
+    it('休暇設定フォームを送信するとonVacationSubmitが呼ばれる', () => {
+      const filledVacationFormData: VacationFormData = {
+        startDate: '2025-01-25',
+        endDate: '2025-01-27',
+        reason: '',
+      };
+
+      render(
+        <ShiftSettingModal
+          staff={mockStaff}
+          activeTab="vacation"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={filledVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      fireEvent.click(screen.getByTestId('shift-modal-submit-button'));
+      expect(mockOnVacationSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('異なるスタッフデータの表示', () => {
+    it('別のスタッフ名がタイトルに表示される', () => {
+      const anotherStaff: Staff = {
+        id: 'staff-2',
+        name: '佐藤花子',
+        email: 'sato@example.com',
+        isActive: true,
+      };
+
+      render(
+        <ShiftSettingModal
+          staff={anotherStaff}
+          activeTab="shift"
+          shiftFormData={defaultShiftFormData}
+          vacationFormData={defaultVacationFormData}
+          error={null}
+          onTabChange={mockOnTabChange}
+          onShiftFormChange={mockOnShiftFormChange}
+          onVacationFormChange={mockOnVacationFormChange}
+          onShiftSubmit={mockOnShiftSubmit}
+          onVacationSubmit={mockOnVacationSubmit}
+          onClose={mockOnClose}
+        />
+      );
+
+      expect(screen.getByTestId('shift-modal-title')).toHaveTextContent('シフト設定 - 佐藤花子');
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/hooks/useAuthFetch.test.ts
+++ b/reserve-app/src/__tests__/unit/hooks/useAuthFetch.test.ts
@@ -1,0 +1,194 @@
+/**
+ * useAuthFetch.ts のユニットテスト
+ *
+ * 認証付きfetchフックとヘルパー関数のテスト
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useAuthFetch, extractErrorMessage } from '@/hooks/useAuthFetch';
+import * as supabaseBrowser from '@/lib/supabase-browser';
+
+// Supabaseのモック
+jest.mock('@/lib/supabase-browser', () => ({
+  createSupabaseBrowserClient: jest.fn(() => ({
+    auth: {
+      getSession: jest.fn(),
+    },
+  })),
+}));
+
+// グローバルfetchのモック
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const mockCreateSupabaseBrowserClient = jest.mocked(supabaseBrowser.createSupabaseBrowserClient);
+
+describe('useAuthFetch', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue(new Response(JSON.stringify({ success: true })));
+  });
+
+  describe('テスト環境での動作（認証スキップ）', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_SKIP_AUTH_IN_TEST;
+
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_SKIP_AUTH_IN_TEST = 'true';
+    });
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_SKIP_AUTH_IN_TEST = originalEnv;
+    });
+
+    it('認証をスキップしてfetchを実行できる', async () => {
+      const { result } = renderHook(() => useAuthFetch());
+
+      await act(async () => {
+        await result.current.authFetch('/api/test');
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/test',
+        expect.objectContaining({
+          headers: expect.any(Headers),
+        })
+      );
+    });
+
+    it('オプション付きでfetchを実行できる', async () => {
+      const { result } = renderHook(() => useAuthFetch());
+
+      await act(async () => {
+        await result.current.authFetch('/api/test', {
+          method: 'POST',
+          body: JSON.stringify({ data: 'test' }),
+        });
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        '/api/test',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ data: 'test' }),
+        })
+      );
+    });
+
+    it('bodyがある場合Content-Typeが自動設定される', async () => {
+      const { result } = renderHook(() => useAuthFetch());
+
+      await act(async () => {
+        await result.current.authFetch('/api/test', {
+          method: 'POST',
+          body: JSON.stringify({ data: 'test' }),
+        });
+      });
+
+      const calledHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(calledHeaders.get('Content-Type')).toBe('application/json');
+    });
+
+    it('既存のヘッダーが保持される', async () => {
+      const { result } = renderHook(() => useAuthFetch());
+
+      await act(async () => {
+        await result.current.authFetch('/api/test', {
+          headers: {
+            'X-Custom-Header': 'custom-value',
+          },
+        });
+      });
+
+      const calledHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(calledHeaders.get('X-Custom-Header')).toBe('custom-value');
+    });
+  });
+
+  describe('本番環境での動作（認証あり）', () => {
+    const originalEnv = process.env.NEXT_PUBLIC_SKIP_AUTH_IN_TEST;
+
+    beforeEach(() => {
+      process.env.NEXT_PUBLIC_SKIP_AUTH_IN_TEST = undefined;
+    });
+
+    afterEach(() => {
+      process.env.NEXT_PUBLIC_SKIP_AUTH_IN_TEST = originalEnv;
+    });
+
+    it('セッションがない場合エラーをスローする', async () => {
+      mockCreateSupabaseBrowserClient.mockReturnValue({
+        auth: {
+          getSession: jest.fn().mockResolvedValue({
+            data: { session: null },
+          }),
+        },
+      } as unknown as ReturnType<typeof supabaseBrowser.createSupabaseBrowserClient>);
+
+      const { result } = renderHook(() => useAuthFetch());
+
+      await expect(async () => {
+        await act(async () => {
+          await result.current.authFetch('/api/test');
+        });
+      }).rejects.toThrow('認証が必要です。再度ログインしてください。');
+    });
+
+    it('セッションがある場合Authorizationヘッダーが設定される', async () => {
+      mockCreateSupabaseBrowserClient.mockReturnValue({
+        auth: {
+          getSession: jest.fn().mockResolvedValue({
+            data: {
+              session: {
+                access_token: 'test-access-token',
+              },
+            },
+          }),
+        },
+      } as unknown as ReturnType<typeof supabaseBrowser.createSupabaseBrowserClient>);
+
+      const { result } = renderHook(() => useAuthFetch());
+
+      await act(async () => {
+        await result.current.authFetch('/api/test');
+      });
+
+      const calledHeaders = mockFetch.mock.calls[0][1].headers;
+      expect(calledHeaders.get('Authorization')).toBe('Bearer test-access-token');
+    });
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it('文字列をそのまま返す', () => {
+    expect(extractErrorMessage('エラーメッセージ')).toBe('エラーメッセージ');
+  });
+
+  it('messageプロパティを持つオブジェクトからメッセージを抽出する', () => {
+    expect(extractErrorMessage({ message: 'オブジェクトエラー' })).toBe('オブジェクトエラー');
+  });
+
+  it('Errorオブジェクトからメッセージを抽出する', () => {
+    expect(extractErrorMessage(new Error('Errorオブジェクト'))).toBe('Errorオブジェクト');
+  });
+
+  it('messageプロパティがない場合デフォルトメッセージを返す', () => {
+    expect(extractErrorMessage({})).toBe('エラーが発生しました');
+  });
+
+  it('nullの場合デフォルトメッセージを返す', () => {
+    expect(extractErrorMessage(null)).toBe('エラーが発生しました');
+  });
+
+  it('undefinedの場合デフォルトメッセージを返す', () => {
+    expect(extractErrorMessage(undefined)).toBe('エラーが発生しました');
+  });
+
+  it('数値の場合デフォルトメッセージを返す', () => {
+    expect(extractErrorMessage(123)).toBe('エラーが発生しました');
+  });
+
+  it('messageが数値の場合文字列に変換する', () => {
+    expect(extractErrorMessage({ message: 404 })).toBe('404');
+  });
+});

--- a/reserve-app/src/__tests__/unit/lib/calendar-utils.test.ts
+++ b/reserve-app/src/__tests__/unit/lib/calendar-utils.test.ts
@@ -1,0 +1,173 @@
+/**
+ * calendar-utils.ts のユニットテスト
+ *
+ * カレンダー処理ユーティリティ関数のテスト
+ */
+
+import {
+  getWeekDates,
+  getWeekRangeText,
+  isClosedDay,
+  formatDateToString,
+  getDayOfWeekJa,
+} from '@/lib/calendar-utils';
+
+describe('calendar-utils', () => {
+  describe('getWeekDates', () => {
+    it('指定された日付から7日分の日付配列を生成する', () => {
+      const weekStart = new Date('2026-01-06');
+      const result = getWeekDates(weekStart);
+
+      expect(result).toHaveLength(7);
+      expect(result[0].getDate()).toBe(6);
+      expect(result[1].getDate()).toBe(7);
+      expect(result[2].getDate()).toBe(8);
+      expect(result[3].getDate()).toBe(9);
+      expect(result[4].getDate()).toBe(10);
+      expect(result[5].getDate()).toBe(11);
+      expect(result[6].getDate()).toBe(12);
+    });
+
+    it('月をまたぐ場合も正しく処理する', () => {
+      const weekStart = new Date('2026-01-29');
+      const result = getWeekDates(weekStart);
+
+      expect(result).toHaveLength(7);
+      expect(result[0].getDate()).toBe(29);
+      expect(result[1].getDate()).toBe(30);
+      expect(result[2].getDate()).toBe(31);
+      expect(result[3].getDate()).toBe(1);
+      expect(result[3].getMonth()).toBe(1); // 2月
+    });
+
+    it('年をまたぐ場合も正しく処理する', () => {
+      const weekStart = new Date('2025-12-29');
+      const result = getWeekDates(weekStart);
+
+      expect(result).toHaveLength(7);
+      expect(result[0].getFullYear()).toBe(2025);
+      expect(result[2].getDate()).toBe(31);
+      expect(result[3].getDate()).toBe(1);
+      expect(result[3].getFullYear()).toBe(2026);
+    });
+
+    it('元の日付オブジェクトを変更しない', () => {
+      const weekStart = new Date('2026-01-06');
+      const originalDate = weekStart.getDate();
+      getWeekDates(weekStart);
+
+      expect(weekStart.getDate()).toBe(originalDate);
+    });
+  });
+
+  describe('getWeekRangeText', () => {
+    it('週の日付範囲をテキスト形式で生成する', () => {
+      const weekStart = new Date('2026-01-06');
+      const result = getWeekRangeText(weekStart);
+
+      expect(result).toBe('2026/01/06 - 2026/01/12');
+    });
+
+    it('月をまたぐ場合も正しく表示する', () => {
+      const weekStart = new Date('2026-01-29');
+      const result = getWeekRangeText(weekStart);
+
+      expect(result).toBe('2026/01/29 - 2026/02/04');
+    });
+
+    it('年をまたぐ場合も正しく表示する', () => {
+      const weekStart = new Date('2025-12-29');
+      const result = getWeekRangeText(weekStart);
+
+      expect(result).toBe('2025/12/29 - 2026/01/04');
+    });
+
+    it('1桁の月日を0埋めする', () => {
+      const weekStart = new Date('2026-01-01');
+      const result = getWeekRangeText(weekStart);
+
+      expect(result).toBe('2026/01/01 - 2026/01/07');
+    });
+  });
+
+  describe('isClosedDay', () => {
+    it('日曜日の場合trueを返す', () => {
+      const sunday = new Date('2026-01-04'); // 日曜日
+      expect(isClosedDay(sunday)).toBe(true);
+    });
+
+    it('月曜日の場合falseを返す', () => {
+      const monday = new Date('2026-01-05'); // 月曜日
+      expect(isClosedDay(monday)).toBe(false);
+    });
+
+    it('火曜日の場合falseを返す', () => {
+      const tuesday = new Date('2026-01-06'); // 火曜日
+      expect(isClosedDay(tuesday)).toBe(false);
+    });
+
+    it('土曜日の場合falseを返す', () => {
+      const saturday = new Date('2026-01-03'); // 土曜日
+      expect(isClosedDay(saturday)).toBe(false);
+    });
+  });
+
+  describe('formatDateToString', () => {
+    it('日付をYYYY-MM-DD形式に変換する', () => {
+      const date = new Date('2026-01-06');
+      expect(formatDateToString(date)).toBe('2026-01-06');
+    });
+
+    it('1桁の月日を0埋めする', () => {
+      const date = new Date('2026-01-01');
+      expect(formatDateToString(date)).toBe('2026-01-01');
+    });
+
+    it('12月の日付を正しく変換する', () => {
+      const date = new Date('2025-12-25');
+      expect(formatDateToString(date)).toBe('2025-12-25');
+    });
+
+    it('月末の日付を正しく変換する', () => {
+      const date = new Date('2026-01-31');
+      expect(formatDateToString(date)).toBe('2026-01-31');
+    });
+  });
+
+  describe('getDayOfWeekJa', () => {
+    it('日曜日を「日」と返す', () => {
+      const sunday = new Date('2026-01-04');
+      expect(getDayOfWeekJa(sunday)).toBe('日');
+    });
+
+    it('月曜日を「月」と返す', () => {
+      const monday = new Date('2026-01-05');
+      expect(getDayOfWeekJa(monday)).toBe('月');
+    });
+
+    it('火曜日を「火」と返す', () => {
+      const tuesday = new Date('2026-01-06');
+      expect(getDayOfWeekJa(tuesday)).toBe('火');
+    });
+
+    it('水曜日を「水」と返す', () => {
+      const wednesday = new Date('2026-01-07');
+      expect(getDayOfWeekJa(wednesday)).toBe('水');
+    });
+
+    it('木曜日を「木」と返す', () => {
+      const thursday = new Date('2026-01-08');
+      expect(getDayOfWeekJa(thursday)).toBe('木');
+    });
+
+    it('金曜日を「金」と返す', () => {
+      const friday = new Date('2026-01-09');
+      expect(getDayOfWeekJa(friday)).toBe('金');
+    });
+
+    it('土曜日を「土」と返す', () => {
+      const saturday = new Date('2026-01-10');
+      expect(getDayOfWeekJa(saturday)).toBe('土');
+    });
+  });
+});

--- a/reserve-app/src/__tests__/unit/lib/supabase-browser.test.ts
+++ b/reserve-app/src/__tests__/unit/lib/supabase-browser.test.ts
@@ -1,0 +1,87 @@
+/**
+ * supabase-browser.ts のユニットテスト
+ *
+ * ブラウザ用Supabaseクライアント生成関数のテスト
+ */
+
+import { createSupabaseBrowserClient } from '@/lib/supabase-browser';
+import * as supabaseSsr from '@supabase/ssr';
+
+// Supabase SSRのモック
+jest.mock('@supabase/ssr', () => ({
+  createBrowserClient: jest.fn(() => ({
+    auth: {
+      getSession: jest.fn(),
+      signInWithPassword: jest.fn(),
+      signOut: jest.fn(),
+    },
+  })),
+}));
+
+const mockCreateBrowserClient = jest.mocked(supabaseSsr.createBrowserClient);
+
+describe('supabase-browser', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('createSupabaseBrowserClient', () => {
+    it('Supabaseクライアントを作成する', () => {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'test-publishable-key';
+
+      const client = createSupabaseBrowserClient();
+
+      expect(mockCreateBrowserClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-publishable-key'
+      );
+      expect(client).toBeDefined();
+    });
+
+    it('NEXT_PUBLIC_SUPABASE_ANON_KEYをフォールバックとして使用する', () => {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = undefined;
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+
+      createSupabaseBrowserClient();
+
+      expect(mockCreateBrowserClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-anon-key'
+      );
+    });
+
+    it('環境変数がない場合はプレースホルダー値を使用する', () => {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = undefined;
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = undefined;
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = undefined;
+
+      createSupabaseBrowserClient();
+
+      expect(mockCreateBrowserClient).toHaveBeenCalledWith(
+        'https://placeholder.supabase.co',
+        'placeholder-anon-key'
+      );
+    });
+
+    it('クライアントにauthメソッドが含まれる', () => {
+      process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+      process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'test-key';
+
+      const client = createSupabaseBrowserClient();
+
+      expect(client.auth).toBeDefined();
+      expect(client.auth.getSession).toBeDefined();
+      expect(client.auth.signInWithPassword).toBeDefined();
+      expect(client.auth.signOut).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## 📝 概要
カバレッジが0%だったファイルに対してユニットテストを追加し、テストカバレッジを向上させました。

## 🎯 関連Issue
- テストカバレッジ向上のリファクタリング作業

## ✅ 実装内容

### 予約管理モーダル（4ファイル）
- [x] `AddReservationModal.test.tsx` - 新規予約追加モーダル
- [x] `EditReservationModal.test.tsx` - 予約編集モーダル
- [x] `DeleteReservationDialog.test.tsx` - 予約削除確認ダイアログ
- [x] `ReservationDetailModal.test.tsx` - 予約詳細モーダル

### スタッフ管理モーダル（4ファイル）
- [x] `AddStaffModal.test.tsx` - スタッフ追加モーダル
- [x] `EditStaffModal.test.tsx` - スタッフ編集モーダル
- [x] `DeleteStaffDialog.test.tsx` - スタッフ削除確認ダイアログ
- [x] `ShiftSettingModal.test.tsx` - シフト設定モーダル

### フック・ユーティリティ（3ファイル）
- [x] `useAuthFetch.test.ts` - 認証付きfetchフック
- [x] `calendar-utils.test.ts` - カレンダーユーティリティ
- [x] `supabase-browser.test.ts` - Supabaseブラウザクライアント

## 📊 テスト結果

| 項目 | 前 | 後 | 変化 |
|-----|---|---|-----|
| テスト数 | 693 | 818 | +125 |
| Statements | - | 91.84% | ✅ |
| Branch | - | 89.27% | ✅ |
| Functions | - | 95.38% | ✅ |
| Lines | - | 94.21% | ✅ |

## 🧪 テスト方法
```bash
npm test
npm run test:coverage
```

## 📋 品質チェック
- [x] ESLintエラー0件
- [x] テスト全件パス（818件）
- [x] カバレッジ目標80%達成

🤖 Generated with [Claude Code](https://claude.com/claude-code)